### PR TITLE
add cryptic-error.md

### DIFF
--- a/cryptic-error-eas.md
+++ b/cryptic-error-eas.md
@@ -4,11 +4,11 @@ Sometimes you'll receive an error that is cryptic and you won't know what to do.
 
 ## The error is informative but I don't know how to fix it
 
-If it isn't covered in our (docs)[https://docs.expo.dev], then you should post about it in our forums.
+If it isn't covered in our [docs](https://docs.expo.dev), then you should post about it in our [forums](https://forums.expo.io/).
 
 ## The error isn't informative
 
-It could be a bug, or we need to show you a better error. Please obtain a stack trace by running `DEBUG=* eas <your-original-command>`. After that, create a (Github issue)[https://github.com/expo/eas-cli/issues]. Please include the following:
+It could be a bug, or we need to show you a better error. Please obtain a stack trace by running `DEBUG=* eas <your-original-command>`. After that, create a [Github issue](https://github.com/expo/eas-cli/issues). Please include the following:
 
 - Your stack trace
 - Your cli version obtained with `eas --version`

--- a/cryptic-error-eas.md
+++ b/cryptic-error-eas.md
@@ -1,0 +1,15 @@
+# Cryptic Error
+
+Sometimes you'll receive an error that is cryptic and you won't know what to do.
+
+## The error is informative but I don't know how to fix it
+
+If it isn't covered in our (docs)[https://docs.expo.dev], then you should post about it in our forums.
+
+## The error isn't informative
+
+It could be a bug, or we need to show you a better error. Please obtain a stack trace by running `DEBUG=* eas <your-original-command>`. After that, create a (Github issue)[https://github.com/expo/eas-cli/issues]. Please include the following:
+
+- Your stack trace
+- Your cli version obtained with `eas --version`
+- Any information or steps that would be helpful for someone to reproduce your issue on their machine.


### PR DESCRIPTION
people using `eas-cli` will sometimes get unhelpful errors and it's really hard to figure what's going on, especially if all the error says is `received unexpected null`. With oclif, we can pass in the `DEBUG=*` env var to get a stack trace, which will help immensely to track down the problem. 