### PR TITLE
Create ipad-requires-fullscreen.md

### DIFF
--- a/ipad-requires-fullscreen.md
+++ b/ipad-requires-fullscreen.md
@@ -3,7 +3,7 @@
 When submitting your app to App Store, you may encounter an error saying that your app orientation doesn't support iPad multitasking. This happens, because Expo apps do not support multitasking by default and, in that case, your app has to be open in fullscreen. 
 
 To fix this, you have to force your app to require fullscreen.
-- If you're using `expo build` / `expo run` / `eas build` to build your app, please set the [`expo.ios.requireFullScreen`](https://docs.expo.io/versions/v42.0.0/config/app/#requirefullscreen) to `true` in `app.json`.
+- If you're using `expo build` / `expo run` / `eas build` to build your app, please set the [`expo.ios.requireFullScreen`](https://docs.expo.io/versions/latest/config/app/#requirefullscreen) to `true` in `app.json`.
   > Prior to Expo SDK 43, this option is `true` by default.
 - If you're using bare workflow and building with Xcode, please follow these steps:
   1. Open your Xcode project.

--- a/ipad-requires-fullscreen.md
+++ b/ipad-requires-fullscreen.md
@@ -1,6 +1,6 @@
 # iPad requires full screen
 
-When submitting your app to App Store, you may encounter an error saying that your app orientation doesn't support iPad multitasking. This happens, because Expo apps do not support multitasking by default and, in that case, your app has to be open in fullscreen. 
+When submitting your app to App Store, you may encounter an error saying that your app orientation doesn't support iPad multitasking. This happens because Expo apps do not support multitasking by default and, when multitasking isn't supported, Apple requires that your app is opened in fullscreen.
 
 To fix this, you have to force your app to require fullscreen.
 - If you're using `expo build` / `expo run` / `eas build` to build your app, please set the [`expo.ios.requireFullScreen`](https://docs.expo.io/versions/latest/config/app/#requirefullscreen) to `true` in `app.json`.

--- a/ipad-requires-fullscreen.md
+++ b/ipad-requires-fullscreen.md
@@ -1,0 +1,11 @@
+# iPad requires full screen
+
+When submitting your app to App Store, you may encounter an error saying that your app orientation doesn't support iPad multitasking. This happens, because Expo apps do not support multitasking by default and, in that case, your app has to be open in fullscreen. 
+
+To fix this, you have to force your app to require fullscreen.
+- If you're using `expo build` / `expo run` / `eas build` to build your app, please set the [`expo.ios.requireFullScreen`](https://docs.expo.io/versions/v42.0.0/config/app/#requirefullscreen) to `true` in `app.json`.
+  > Prior to Expo SDK 43, this option is `true` by default.
+- If you're using bare workflow and building with Xcode, please follow these steps:
+  1. Open your Xcode project.
+  2. Go to `General` -> `Deployment Info`.
+  3. Select the `Requires full screen` checkbox.


### PR DESCRIPTION
Adds FYI page, which explains https://github.com/expo/eas-cli/issues/179#issuecomment-873395982.

The FYI link is going to be displayed in `eas-cli` when error from the issue above happens during `eas submit -p ios`