### PR TITLE
Fix the capitalization of client app's bundle ID

### DIFF
--- a/bundle-identifier.md
+++ b/bundle-identifier.md
@@ -1,3 +1,3 @@
 # Bundle Identifier
 
-A unique id for your application using [reverse domain name notation](https://en.wikipedia.org/wiki/Reverse_domain_name_notation). The bundle identifier for the Expo client app is `host.exp.exponent`, but it could also be `io.expo.client` or any other unique string that follows this notation. You don't need to own the domain to use the bundle identifier.
+A unique id for your application using [reverse domain name notation](https://en.wikipedia.org/wiki/Reverse_domain_name_notation). The bundle identifier for the Expo client app is [`host.exp.Exponent`](https://github.com/expo/expo/blob/d2cedae3ac78718bfe8dcac6f0375412c7c178ff/ios/Exponent.xcodeproj/project.pbxproj#L3998), but it could also be `io.expo.client` or any other unique string that follows this notation. You don't need to own the domain to use the bundle identifier.


### PR DESCRIPTION
This fixes the Expo client application's bundle identifier from
`host.exp.exponent` to `host.exp.Exponent` and also adds a reference
link for verification. The lowercase bundle id doesn't work with `xcrun
simctl get_app_container`.