### PR TITLE
Fix jsBundleURLForBundleRoot call in expo-modules-migration.md

### DIFF
--- a/expo-modules-migration.md
+++ b/expo-modules-migration.md
@@ -579,7 +579,7 @@ Apply all changes listed below to the files in `/ios`.
 
  - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
   #ifdef DEBUG
-   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
   #else
 -  return [[EXUpdatesAppController sharedInstance] launchAssetUrl];
 +  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];


### PR DESCRIPTION
This change was necessary to fix a build error in my code when using React Native 0.68.1. I got the correct line of code by creating a new React Native project (`npx react-native init`) and looking at `AppDelegate.m`.