### PR TITLE
[docs] fix invalid JSON suggestions

### DIFF
--- a/android-navigation-bar-visible-deprecated.md
+++ b/android-navigation-bar-visible-deprecated.md
@@ -46,7 +46,7 @@ setStatusBarHidden(true, "none");
 ```json
 {
   "androidStatusBar": {
-    "hidden": "true"
+    "hidden": true
   },
   "plugins": [
     [
@@ -95,7 +95,7 @@ setStatusBarHidden(true, "none");
 ```json
 {
   "androidStatusBar": {
-    "hidden": "true"
+    "hidden": true
   },
   "plugins": [
     [
@@ -167,7 +167,7 @@ function useStickyImmersiveReset() {
 ```json
 {
   "androidStatusBar": {
-    "hidden": "true"
+    "hidden": true
   },
   "plugins": [
     [


### PR DESCRIPTION

Currently this doc suggests invalid JSON for the EAS build process. Expo doctor currently complains about the suggested format in this FYI document. @EvanBacon I'm assuming the booleans were accidentally wrapped in quotes when drafting this help document? Or is Expo doctor wrong? 

Logs from EAS Build:

```
Running "expo doctor"
[stderr] [21:40:55] Error: Problem validating fields in app.json. Learn more: https://docs.expo.dev/workflow/configuration/
[stderr] [21:40:55]  • Field: androidStatusBar.hidden - should be boolean.
```