### PR TITLE
Use `overlay-swipe` for `sticky-immersive`

### DIFF
--- a/android-navigation-bar-visible-deprecated.md
+++ b/android-navigation-bar-visible-deprecated.md
@@ -120,7 +120,7 @@ import { setStatusBarHidden } from "expo-status-bar";
 
 NavigationBar.setPositionAsync("absolute");
 NavigationBar.setVisibilityAsync("hidden");
-NavigationBar.setBehaviorAsync("inset-swipe");
+NavigationBar.setBehaviorAsync("overlay-swipe");
 NavigationBar.setBackgroundColorAsync("#00000080"); // `rgba(0,0,0,0.5)`
 setStatusBarHidden(true, "none");
 ```
@@ -175,7 +175,7 @@ function useStickyImmersiveReset() {
       {
         "position": "absolute",
         "visibility": "hidden",
-        "behavior": "inset-swipe",
+        "behavior": "overlay-swipe",
         "backgroundColor": "#00000080"
       }
     ]


### PR DESCRIPTION
Hi there! I __think__ `androidNavigationBar.visible = "sticky-immersive"` was using an `overlay-swipe` behaviour by default, so if we want to make it replicate it with `expo-navigation-bar` we might wanna recommend `overlay-swipe` there as well... I guess?  
- [Related Twitter discussion here](https://twitter.com/mazzarolomatteo/status/1622859164325126144)  
- [PR in an app where I'm using this change](https://github.com/mmazzarolo/breathly-app/pull/100/commits/8ab511bea781f69bed7524286d26480b31d7a3eb)