### PR TITLE
Update intel-to-m1.md

### DIFF
--- a/intel-to-m1.md
+++ b/intel-to-m1.md
@@ -15,7 +15,7 @@ For example:
  "build": {
     "fast": {
       "ios": {
-        "resourceClass": "m1-medium"
+        "resourceClass": "m-medium"
       }
     },
     "development": {


### PR DESCRIPTION
This is just a simple update to the instructions based on a newer Expo's blog post: https://blog.expo.dev/m1-workers-on-eas-build-dcaa2c1333ad#ad50

According to the post, `m1-medium` will continue to work, but the recommended resourceClass now is `m-medium`.

> The instructions in previous version of this post said to use the “m1-medium” resource class. This has been replaced by the “m-medium” resource class, which more accurately describes the M-series of builders (M1, M2). The “m1-medium” resource class will continue to work but “m-medium” is now recommended.