### PR TITLE
eas update: add missing headers guide

### DIFF
--- a/eas-update-missing-headers.md
+++ b/eas-update-missing-headers.md
@@ -4,11 +4,11 @@ You've made a request to EAS Update without the required request headers.
 
 ## Fetching manually
 
-If you are manually fetching the manifest from the Expo servers with a command like `wget` or `curl`, you can specify the missing information in query parameters instead of request headers for an easier debugging experience. See more details [here](https://docs.expo.dev/eas-update/debug/#inspecting-manifests-manually).
+If you are manually fetching the manifest from the Expo servers with a command like `wget` or `curl`, you can specify the missing information in query parameters instead of request headers for an easier debugging experience. See more details [here](https://docs.expo.dev/eas-update/debug-advanced/#inspecting-manifests-manually).
 
 ## Prebuild
 
-If you've encountered this error after running `npx expo prebuild` and have built locally instead of using EAS Build, make sure you've followed the correct steps to configure EAS Update. See [here](https://docs.expo.dev/eas-update/build-locally/) and [here](https://docs.expo.dev/eas-update/debug/#debugging-of-native-code-while-loading-the-app-through-expo-updates) for more information.
+If you've encountered this error after running `npx expo prebuild` and have built locally instead of using EAS Build, make sure you've followed the correct steps to configure EAS Update. See [here](https://docs.expo.dev/eas-update/build-locally/) and [here](https://docs.expo.dev/eas-update/debug-advanced/#debugging-of-native-code-while-loading-the-app-through-expo-updates) for more information.
 
 ## Verify configuration
 

--- a/eas-update-missing-headers.md
+++ b/eas-update-missing-headers.md
@@ -1,0 +1,15 @@
+# Missing Headers in EAS Update
+
+You've made a request to the EAS Update without the required headers.
+
+## Fetching manually
+
+If you are manually fetching the manifest from the Expo servers with a command like `wget` or `curl`, you can specify the missing information in query parameters instead of headers for an easier debugging experience. See more details [here](https://docs.expo.dev/eas-update/debug/#inspecting-manifests-manually).
+
+## Prebuild
+
+If you've encountered this error after running `npx expo prebuild` and have built locally instead of using EAS Build, make sure you've followed the correct steps to configure EAS Update. See [here](https://docs.expo.dev/eas-update/build-locally/) and [here](https://docs.expo.dev/eas-update/debug/#debugging-of-native-code-while-loading-the-app-through-expo-updates) for more information.
+
+## Verify configuration
+
+If you've already gone through the [setup guide](https://docs.expo.dev/eas-update/getting-started/), verify that you've configured EAS Update correctly by following [this guide](https://docs.expo.dev/eas-update/debug/).

--- a/eas-update-missing-headers.md
+++ b/eas-update-missing-headers.md
@@ -1,10 +1,10 @@
 # Missing Headers in EAS Update
 
-You've made a request to EAS Update without the required headers.
+You've made a request to EAS Update without the required request headers.
 
 ## Fetching manually
 
-If you are manually fetching the manifest from the Expo servers with a command like `wget` or `curl`, you can specify the missing information in query parameters instead of headers for an easier debugging experience. See more details [here](https://docs.expo.dev/eas-update/debug/#inspecting-manifests-manually).
+If you are manually fetching the manifest from the Expo servers with a command like `wget` or `curl`, you can specify the missing information in query parameters instead of request headers for an easier debugging experience. See more details [here](https://docs.expo.dev/eas-update/debug/#inspecting-manifests-manually).
 
 ## Prebuild
 
@@ -12,4 +12,4 @@ If you've encountered this error after running `npx expo prebuild` and have buil
 
 ## Verify configuration
 
-If you've already gone through the [setup guide](https://docs.expo.dev/eas-update/getting-started/), verify that you've configured EAS Update correctly by following [this guide](https://docs.expo.dev/eas-update/debug/).
+If your app is encountering this error and you've already completed the [setup guide](https://docs.expo.dev/eas-update/getting-started/), verify that you've configured EAS Update correctly by following [this guide](https://docs.expo.dev/eas-update/debug/).

--- a/eas-update-missing-headers.md
+++ b/eas-update-missing-headers.md
@@ -1,6 +1,6 @@
 # Missing Headers in EAS Update
 
-You've made a request to the EAS Update without the required headers.
+You've made a request to EAS Update without the required headers.
 
 ## Fetching manually
 


### PR DESCRIPTION
A lot of users debugging EAS Update will receive a 'missing headers' error message from www if their app is not configured properly. Linking to this `expo.fyi`  in the `www` error will give folks a starting point to debug, depending on their use case
