### PR TITLE
Add info about v10.3.0 Firebase JS SDK auth persistence

### DIFF
--- a/firebase-js-auth-setup.md
+++ b/firebase-js-auth-setup.md
@@ -1,13 +1,40 @@
 # Recommended Additional Setup for Firebase Authentication
-With the release of [Firebase JS SDK `v10.0.0`](https://npmjs.com/firebase), React Native Persistence is now built directly into the library. If you are using any version **above** `v10.0.0` of Firebase JS SDK, you **do not need to follow any of the steps on this page**.
 
-If you are using a version below `v10.0.0` of the SDK, follow the steps described in this guide.
+Follow the steps described in this guide to enable auth persistence depending on the Firebase version your project uses.
 
-## Switching to the React Native Persistence Manager
-The Firebase JS SDK has a persistence manager that uses local storage in React Native. You can update your initialization code as such:
+## For Firebase JS SDK version 10 and above
+
+### Enable auth persistence
+
+With the release of `v10.0.0`, the Firebase library [briefly supported local persistence](https://firebase.google.com/support/release-notes/js#version_1030_-_august_22_2023) but with the release of `v10.3.0`, it recommends explicitly importing AsyncStorage as such:
+
 ```js
 import { initializeApp } from "firebase/app";
-import { initializeAuth, reactNativeLocalPersistence } from "firebase/auth"
+import { initializeAuth, getReactNativePersistence } from "firebase/auth";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const firebaseConfig = {
+  // config copied from Firebase console when creating a web app
+};
+
+const app = initializeApp(firebaseConfig);
+
+const auth = initializeAuth(app, {
+  persistence: getReactNativePersistence(AsyncStorage),
+});
+
+// getAuth() can be used any time after initialization
+```
+
+## For Firebase JS SDK version 9 and below
+
+### Switching to the React Native Persistence Manager
+
+The Firebase JS SDK has a persistence manager that uses local storage in React Native. You can update your initialization code as such:
+
+```js
+import { initializeApp } from "firebase/app";
+import { initializeAuth, reactNativeLocalPersistence } from "firebase/auth";
 
 const firebaseConfig = {
   // config copied from Firebase console when creating a web app
@@ -16,20 +43,21 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 
 // add this to init auth with persistence
-initializeAuth(app,
-  {
-    persistence: reactNativeLocalPersistence
-  }
-)
+initializeAuth(app, {
+  persistence: reactNativeLocalPersistence,
+});
 ```
+
 Depending on your version of Firebase and React Native, you may see deprecation warnings or failures, as Firebase uses React Native core local storage. If that is the case, the instructions for using a custom persistence manager can help.
 
-## Using a Custom Persistence Manager
+### Using a Custom Persistence Manager
+
 Firebase Auth can be initialized with a custom persistence manager in cases where it doesn't support `@react-native-async-storage/async-storage`:
+
 ```js
 import { initializeApp } from "firebase/app";
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { initializeAuth, getReactNativePersistence } from "firebase/auth"
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { initializeAuth, getReactNativePersistence } from "firebase/auth";
 
 const firebaseConfig = {
   // config copied from Firebase console when creating a web app
@@ -39,34 +67,33 @@ const app = initializeApp(firebaseConfig);
 
 // add code below to init auth with custom persistence
 
-const myReactNativeLocalPersistence =
-  getReactNativePersistence({
-    getItem(...args) {
-      // Called inline to avoid deprecation warnings on startup.
-      return AsyncStorage.getItem(...args);
-    },
-    setItem(...args) {
-      // Called inline to avoid deprecation warnings on startup.
-      return AsyncStorage.setItem(...args);
-    },
-    removeItem(...args) {
-      // Called inline to avoid deprecation warnings on startup.
-      return AsyncStorage.removeItem(...args);
-    },
-  });
+const myReactNativeLocalPersistence = getReactNativePersistence({
+  getItem(...args) {
+    // Called inline to avoid deprecation warnings on startup.
+    return AsyncStorage.getItem(...args);
+  },
+  setItem(...args) {
+    // Called inline to avoid deprecation warnings on startup.
+    return AsyncStorage.setItem(...args);
+  },
+  removeItem(...args) {
+    // Called inline to avoid deprecation warnings on startup.
+    return AsyncStorage.removeItem(...args);
+  },
+});
 
-initializeAuth(app,
-  {
-    persistence: myReactNativeLocalPersistence
-  }
-)
+initializeAuth(app, {
+  persistence: myReactNativeLocalPersistence,
+});
 ```
 
-## Web Compatiblity
+### Web Compatiblity
+
 The above setup works for web when **web.bundler** is set to "metro" in your Expo Config, in addition to iOS and Android. If you're using Webpack, the `getReactNativePersistence` import will not work. You can instead initialize Firebase as such:
+
 ```js
 import { initializeApp } from "firebase/app";
-import { initializeAuth, browserLocalPersistence } from "firebase/auth"
+import { initializeAuth, browserLocalPersistence } from "firebase/auth";
 
 const firebaseConfig = {
   // config copied from Firebase console when creating a web app
@@ -74,11 +101,9 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 
-initializeAuth(app,
-   {
-    persistence: browserLocalPersistence
-  }
-)
+initializeAuth(app, {
+  persistence: browserLocalPersistence,
+});
 ```
 
 Note that `browserLocalPersistence` will not exist when running on iOS and Android, so you will need to use `Platform` to switch between configuration methods for web and native.

--- a/firebase-js-auth-setup.md
+++ b/firebase-js-auth-setup.md
@@ -28,7 +28,7 @@ const auth = initializeAuth(app, {
 
 ## For Firebase JS SDK version 9 and below
 
-### Switching to the React Native Persistence Manager
+### Switch to the React Native Persistence Manager
 
 The Firebase JS SDK has a persistence manager that uses local storage in React Native. You can update your initialization code as such:
 
@@ -50,7 +50,7 @@ initializeAuth(app, {
 
 Depending on your version of Firebase and React Native, you may see deprecation warnings or failures, as Firebase uses React Native core local storage. If that is the case, the instructions for using a custom persistence manager can help.
 
-### Using a Custom Persistence Manager
+### Use a Custom Persistence Manager
 
 Firebase Auth can be initialized with a custom persistence manager in cases where it doesn't support `@react-native-async-storage/async-storage`:
 


### PR DESCRIPTION
## Why

Close #127 

As brought up and info shared in the #127, Firebase JS SDK from v10.3.0 and above requires explicitly importing AsyncStorage library. They have also removed the automatic persistence management for React Native from the JS SDK.

## How

This PR
- Adds a new top-level section about setting up persistence when using v10.3.0
- Also adds a new top-level section to differentiate the steps already mentioned for v9 and below