### PR TITLE
[docs] Create a start.md to add links about development builds

### DIFF
--- a/start.md
+++ b/start.md
@@ -2,6 +2,5 @@
 
 [Development builds](https://docs.expo.dev/develop/development-builds/introduction/) of your app are debug builds of a project with the `expo-dev-client` library.
 
-To learn more about creating native builds, see [Create a development build using EAS](https://docs.expo.dev/develop/development-builds/create-a-build/) to learn how to build in the cloud, or learn [how to compile your project locally with Android Studio or Xcode](https://docs.expo.dev/guides/local-app-development/#local-app-compilation).
+See [Create a development build using EAS](https://docs.expo.dev/develop/development-builds/create-a-build/) to learn how to build in the cloud, or learn [how to compile your project locally with Android Studio or Xcode](https://docs.expo.dev/guides/local-app-development/#local-app-compilation).
 
-Alternatively, you can also learn how to [compile your project locally with Android Studio or Xcode](https://docs.expo.dev/guides/local-app-development/#local-app-compilation).

--- a/start.md
+++ b/start.md
@@ -1,0 +1,7 @@
+# Start with a development build
+
+Development builds of your app are Debug builds of your project that has the `expo-dev-client` library installed in your project's dependencies.
+
+To learn more, see [Create a development build using EAS](https://docs.expo.dev/develop/development-builds/create-a-build/).
+
+Alternatively, you can also learn how to [compile your project locally with Android Studio or Xcode](https://docs.expo.dev/guides/local-app-development/#local-app-compilation).

--- a/start.md
+++ b/start.md
@@ -1,6 +1,6 @@
 # Start with a development build
 
-Development builds of your app are Debug builds of your project that has the `expo-dev-client` library installed in your project's dependencies.
+[Development builds](https://docs.expo.dev/develop/development-builds/introduction/) of your app are Debug builds of your project that has the `expo-dev-client` library installed in your project's dependencies.
 
 To learn more, see [Create a development build using EAS](https://docs.expo.dev/develop/development-builds/create-a-build/).
 

--- a/start.md
+++ b/start.md
@@ -1,7 +1,7 @@
 # Start with a development build
 
-[Development builds](https://docs.expo.dev/develop/development-builds/introduction/) of your app are Debug builds of your project that has the `expo-dev-client` library installed in your project's dependencies.
+[Development builds](https://docs.expo.dev/develop/development-builds/introduction/) of your app are debug builds of a project with the `expo-dev-client` library.
 
-To learn more, see [Create a development build using EAS](https://docs.expo.dev/develop/development-builds/create-a-build/).
+To learn more about creating native builds, see [Create a development build using EAS](https://docs.expo.dev/develop/development-builds/create-a-build/) to learn how to build in the cloud, or learn [how to compile your project locally with Android Studio or Xcode](https://docs.expo.dev/guides/local-app-development/#local-app-compilation).
 
 Alternatively, you can also learn how to [compile your project locally with Android Studio or Xcode](https://docs.expo.dev/guides/local-app-development/#local-app-compilation).


### PR DESCRIPTION
## Why

Fixes #125 

## How

- By adding links to Development build with EAS and compiling app locally.