### PR TITLE
Fix typos in barcode-scanner-to-expo-camera.md

### DIFF
--- a/barcode-scanner-to-expo-camera.md
+++ b/barcode-scanner-to-expo-camera.md
@@ -27,7 +27,7 @@ export default function App() {
 
   useEffect(() => {
     const getBarCodeScannerPermissions = async () => {
-      const { status } = await BarCodeScanner.requestPermissionsAsync();
+      const { status } = await BarCodeScanner.requestCameraPermissionsAsync();
       setHasPermission(status === "granted");
     };
 
@@ -49,7 +49,7 @@ export default function App() {
   return (
     <View style={styles.container}>
       <BarCodeScanner
-        onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
+        onBarcodeScanned={scanned ? undefined : handleBarCodeScanned}
         style={StyleSheet.absoluteFillObject}
       />
       {scanned && (


### PR DESCRIPTION
Fix typos to fit expo-camera/next package's prop renames so that the code copied will work without additional typo fixes.