### PR TITLE
docs: Add the wrapping process in sentry-expo-migration.md

### DIFF
--- a/sentry-expo-migration.md
+++ b/sentry-expo-migration.md
@@ -28,6 +28,15 @@ On your terminal, run the following commands to remove `sentry-expo` and install
 - Replace any usage of `Sentry.Native.*` with `Sentry.*`, where `Sentry` is imported from `@sentry/react-native` as above (e.g. `Sentry.Native.captureException` -> `Sentry.captureException`)
 - Replace any usage of `Sentry.Browser.*` with `Sentry.*`, where `Sentry` is imported from `@sentry/browser`.
 
+## Wrap your App with `Sentry.wrap()`:
+```javascript
+import * as Sentry from '@sentry/react-native';
+
+// Your App component here
+
+export default Sentry.wrap(App);
+```
+
 ## Update your `app.json` to include the Sentry plugin and remove the hook
 
 - Remove the the `sentry-expo` `postPublish` hook from your `app.json` if you have it.

--- a/sentry-expo-migration.md
+++ b/sentry-expo-migration.md
@@ -28,8 +28,9 @@ On your terminal, run the following commands to remove `sentry-expo` and install
 - Replace any usage of `Sentry.Native.*` with `Sentry.*`, where `Sentry` is imported from `@sentry/react-native` as above (e.g. `Sentry.Native.captureException` -> `Sentry.captureException`)
 - Replace any usage of `Sentry.Browser.*` with `Sentry.*`, where `Sentry` is imported from `@sentry/browser`.
 
-## Wrap your App with `Sentry.wrap()`:
-```javascript
+## Wrap your App with `Sentry.wrap()`
+
+```js
 import * as Sentry from '@sentry/react-native';
 
 // Your App component here


### PR DESCRIPTION
When reading the Expo's sentry docs for SDK 50 (https://docs.expo.dev/guides/using-sentry/) I've come across this step of wrapping the App with `Sentry.wrap()`. This is missing from the migration guide.