### PR TITLE
Fix typo on prop in barcode scanner to camera migration example code

### DIFF
--- a/barcode-scanner-to-expo-camera.md
+++ b/barcode-scanner-to-expo-camera.md
@@ -105,7 +105,7 @@ export default function App() {
       <CameraView
         onBarcodeScanned={scanned ? undefined : handleBarCodeScanned}
         barcodeScannerSettings={{
-          barCodeTypes: ["qr", "pdf417"],
+          barcodeTypes: ["qr", "pdf417"],
         }}
         style={StyleSheet.absoluteFillObject}
       />


### PR DESCRIPTION
The prop is `barcodeTypes` not `barCodeTypes`