### PR TITLE
docs: Add meta advice about questions (mostly for Discord)

### DIFF
--- a/advice-dont-ask-about-solutions.md
+++ b/advice-dont-ask-about-solutions.md
@@ -12,12 +12,12 @@ What may have happened here is that you just asked a question that mostly consis
 of what you tried or waht you're trying to do, rather than giving context on **why
 it is you think you have to do this**. For example,
 
-> You wanted to do <X>.
-> You ran into a problem with <X> or don't know how to do <X>.
-> You figured, you can solve <X> by doing <Y>.
-> You ran into a problem with <Y> or don't know how to do <Y>.
-> You asked for help with <Y>.
-> Others help you with <Y> but are confused, because they don't know about <X>.
+> You wanted to do `<X>`.
+> You ran into a problem with `<X>` or don't know how to do `<X>`.
+> You figured, you can solve `<X>` by doing `<Y>`.
+> You ran into a problem with `<Y>` or don't know how to do `<Y>`.
+> You asked for help with `<Y>`.
+> Others help you with `<Y>` but are confused, because they don't know about `<X>`.
 
 This leads to enormous amounts of wasted time and energy, both on your part, and
 on the part of those trying to help you.
@@ -39,8 +39,8 @@ did before you started working on what you posted about.**
 
 If you're not sure what to ask about, think back of when you started your task, and
 explain:
-> I started to work on <task> and wanted to achieve <goal>.
-> Instead of <expectation>, I encountered <problem>.
+> I started to work on `<task>` and wanted to achieve `<goal>`.
+> Instead of `<expectation>`, I encountered `<problem>`.
 
 If you talk about your original goals and problems rather than your later solutions,
 you're telling others the full story of what happened and you may save yourself and
@@ -48,9 +48,9 @@ them some time having to hunt down where your problem originally started.
 
 ### tl;dr
 
-To summarize, don't ask "Why is <solution> not working?", but rather ask:
-- "How do I solve <problem> given <context>?"
-- "I tried <solution> because of <problem> while working on <context>. What is an alternative solution?"
-- "I ran into <issue>, when trying to do <context>. What's happening and what's a possible solution?"
+To summarize, don't ask "Why is `<solution>` not working?", but rather ask:
+- "How do I solve `<problem>` given `<context>`?"
+- "I tried `<solution>` because of `<problem>` while working on `<context>`. What is an alternative solution?"
+- "I ran into `<issue>`, when trying to do `<context>`. What's happening and what's a possible solution?"
 
 [^1]: This document was inspired by https://xyproblem.info/

--- a/advice-dont-ask-about-solutions.md
+++ b/advice-dont-ask-about-solutions.md
@@ -14,7 +14,7 @@ We often encounter problems that appear to have multiple, possible solutions. Th
 solutions themselves however could cause more problems, which in turn have multiple
 solutions, which in turn may cause more problems...
 
-What may have happened here is that you asked a question that mostly consists
+You may have asked a question that mostly consists
 of what you tried or what you're trying to do, rather than giving context on **why
 it is you think you have to do this in the first place**. For example,
 

--- a/advice-dont-ask-about-solutions.md
+++ b/advice-dont-ask-about-solutions.md
@@ -4,6 +4,12 @@ You may have been sent this document because **you asked about solutions** to a 
 rather than the problem itself, or without explaining your original problem.
 This is called ["The XY Problem"](https://en.wikipedia.org/wiki/XY_problem)
 
+> [!TIP]
+> **tl;dr:** don't ask "Why is `<solution>` not working?", but rather ask:
+> - "How do I solve `<problem>` given `<context>`?"
+> - "I tried `<solution>` because of `<problem>` while working on `<context>`. What is an alternative solution?"
+> - "I ran into `<issue>`, when trying to do `<context>`. What's happening and what's a possible solution?"
+
 We often encounter problems that appear to have multiple, possible solutions. These
 solutions themselves however could cause more problems, which in turn have multiple
 solutions, which in turn may cause more problems...
@@ -45,12 +51,5 @@ explain:
 If you talk about your original goals and problems rather than your later solutions,
 you're telling others the full story of what happened and you may save yourself and
 them some time having to hunt down where your problem originally started.
-
-### tl;dr
-
-To summarize, don't ask "Why is `<solution>` not working?", but rather ask:
-- "How do I solve `<problem>` given `<context>`?"
-- "I tried `<solution>` because of `<problem>` while working on `<context>`. What is an alternative solution?"
-- "I ran into `<issue>`, when trying to do `<context>`. What's happening and what's a possible solution?"
 
 [^1]: This document was inspired by https://xyproblem.info/

--- a/advice-dont-ask-about-solutions.md
+++ b/advice-dont-ask-about-solutions.md
@@ -9,46 +9,31 @@ This is called ["The XY Problem"](https://en.wikipedia.org/wiki/XY_problem)
 > - "I tried `<solution>` because of `<problem>` while working on `<context>`. What is an alternative solution?"
 > - "I ran into `<issue>`, when trying to do `<context>`. What's happening and what's a possible solution?"
 
-We often encounter problems that appear to have multiple, possible solutions. These
-solutions themselves however could cause more problems, which in turn have multiple
-solutions, which in turn may cause more problems...
+We often encounter problems that appear to have multiple, possible solutions. These solutions themselves however could cause more problems, which in turn have multiple solutions, which in turn may cause more problems...
 
-You may have asked a question that mostly consists
-of what you tried or what you're trying to do, rather than giving context on **why
-it is you think you have to do this in the first place**. For example,
+You may have asked a question that mostly consists of what you tried or what you're trying to do, rather than giving context on **why it is you think you have to do this in the first place**. For example,
 
-> You wanted to do `<X>`.<br/>
-> You ran into a problem with `<X>` or don't know how to do `<X>`.<br/>
-> You figured, you can solve `<X>` by doing `<Y>`.<br/>
-> You ran into a problem with `<Y>` or don't know how to do `<Y>`.<br/>
-> You asked for help with `<Y>`.<br/>
-> Others help you with `<Y>` but are confused, because they don't know about `<X>`.
+> User A: "How do I replace the display on my iPhone?"<br/>
+> User B: "Do this and that"<br/>
+> User C: "Why do you need to replace the display?"<br/>
+> User A: "Because my iPhone screen is too dark to read."<br/>
+> User C: "That's weird. Make sure to check the display brightness settings!"<br/>
+> User A: "Ah, thank you, that fixed it!"
 
-This leads to enormous amounts of wasted time and energy, both on your part, and
-on the part of those trying to help you.
-
+Leading into conversations with an assumed solution leads to wasted time and energy, both for you and those trying to help you.
 If you come to someone with a solution rather than the problem, you're denying them:
 - the chance to evaluate if your solution may solve the problem
 - the context on why this problem occurred and what you did
 - reproduction steps that they may recognize
 
-In the best case scenario, you may have mentioned your original problem, but spent
-more time describing the solution. **Instead, explain how you ran into the problem,
-and set your solution aside, so others have a chance to arrive at the same point
-you did.**
+In the best case scenario, you may have mentioned your original problem, but spent more time describing the solution. **Instead, explain how you ran into the problem, and set your solution aside, so others have a chance to arrive at the same point you did.**
 
-In the worst case scenario, you may have completely omitted information on your
-original problem, and you may have been sent this document because the issue you
-posted above hints at another problem. **Instead, explain the context of what you
-did before you started working on what you posted about.**
+In the worst case scenario, you may have completely omitted information on your original problem, and you may have been sent this document because the issue you posted above hints at another problem. **Instead, explain the context of what you did before you started working on what you posted about.**
 
-If you're not sure what to ask about, think back of when you started your task, and
-explain:
+If you're not sure what to ask about, think back of when you started your task, and explain:
 > I started to work on `<task>` and wanted to achieve `<goal>`.
 > Instead of `<expectation>`, I encountered `<problem>`.
 
-If you talk about your original goals and problems rather than your later solutions,
-you're telling others the full story of what happened and you may save yourself and
-them some time having to hunt down where your problem originally started.
+If you talk about your original goals and problems rather than your later solutions, you're telling others the full story of what happened and you may save yourself and them some time having to hunt down where your problem originally started.
 
 [^1]: This document was inspired by https://xyproblem.info/

--- a/advice-dont-ask-about-solutions.md
+++ b/advice-dont-ask-about-solutions.md
@@ -1,7 +1,6 @@
 # Don't ask about solutions[^1]
 
-You may have been sent this document because **you asked about solutions** to a problem,
-rather than the problem itself, or without explaining your original problem.
+You may have been sent this document because **you asked about solutions** to a problem, rather than the problem itself, or without explaining your original problem.
 This is called ["The XY Problem"](https://en.wikipedia.org/wiki/XY_problem)
 
 > [!TIP]

--- a/advice-dont-ask-about-solutions.md
+++ b/advice-dont-ask-about-solutions.md
@@ -1,0 +1,56 @@
+# Don't ask about solutions[^1]
+
+You may have been sent this document because **you asked about solutions** to a problem,
+rather than the problem itself, or without explaining your original problem.
+This is called ["The XY Problem"](https://en.wikipedia.org/wiki/XY_problem)
+
+We often encounter problems that appear to have multiple, possible solutions. These
+solutions themselves however could cause more problems, which in turn have multiple
+solutions, which in turn may cause more problems...
+
+What may have happened here is that you just asked a question that mostly consists
+of what you tried or waht you're trying to do, rather than giving context on **why
+it is you think you have to do this**. For example,
+
+> You wanted to do <X>.
+> You ran into a problem with <X> or don't know how to do <X>.
+> You figured, you can solve <X> by doing <Y>.
+> You ran into a problem with <Y> or don't know how to do <Y>.
+> You asked for help with <Y>.
+> Others help you with <Y> but are confused, because they don't know about <X>.
+
+This leads to enormous amounts of wasted time and energy, both on your part, and
+on the part of those trying to help you.
+
+If you come to someone with a solution rather than the problem, you're denying them:
+- the chance to evaluate if your solution may solve the problem
+- the context on why this problem occurred and what you did
+- reproduction steps that they may recognize
+
+In the best case scenario, you may have mentioned your original problem, but spent
+more time describing the solution. **Instead, explain how you ran into the problem,
+and set your solution aside, so others have a chance to arrive at the same point
+you did.**
+
+In the worst case scenario, you may have completely omitted information on your
+original problem, and you may have been sent this document because the issue you
+posted above hints at another problem. **Instead, explain the context of what you
+did before you started working on what you posted about.**
+
+If you're not sure what to ask about, think back of when you started your task, and
+explain:
+> I started to work on <task> and wanted to achieve <goal>.
+> Instead of <expectation>, I encountered <problem>.
+
+If you talk about your original goals and problems rather than your later solutions,
+you're telling others the full story of what happened and you may save yourself and
+them some time having to hunt down where your problem originally started.
+
+### tl;dr
+
+To summarize, don't ask "Why is <solution> not working?", but rather ask:
+- "How do I solve <problem> given <context>?"
+- "I tried <solution> because of <problem> while working on <context>. What is an alternative solution?"
+- "I ran into <issue>, when trying to do <context>. What's happening and what's a possible solution?"
+
+[^1]: This document was inspired by https://xyproblem.info/

--- a/advice-dont-ask-about-solutions.md
+++ b/advice-dont-ask-about-solutions.md
@@ -18,11 +18,11 @@ What may have happened here is that you asked a question that mostly consists
 of what you tried or what you're trying to do, rather than giving context on **why
 it is you think you have to do this in the first place**. For example,
 
-> You wanted to do `<X>`.
-> You ran into a problem with `<X>` or don't know how to do `<X>`.
-> You figured, you can solve `<X>` by doing `<Y>`.
-> You ran into a problem with `<Y>` or don't know how to do `<Y>`.
-> You asked for help with `<Y>`.
+> You wanted to do `<X>`.<br/>
+> You ran into a problem with `<X>` or don't know how to do `<X>`.<br/>
+> You figured, you can solve `<X>` by doing `<Y>`.<br/>
+> You ran into a problem with `<Y>` or don't know how to do `<Y>`.<br/>
+> You asked for help with `<Y>`.<br/>
 > Others help you with `<Y>` but are confused, because they don't know about `<X>`.
 
 This leads to enormous amounts of wasted time and energy, both on your part, and

--- a/advice-dont-ask-about-solutions.md
+++ b/advice-dont-ask-about-solutions.md
@@ -8,9 +8,9 @@ We often encounter problems that appear to have multiple, possible solutions. Th
 solutions themselves however could cause more problems, which in turn have multiple
 solutions, which in turn may cause more problems...
 
-What may have happened here is that you just asked a question that mostly consists
-of what you tried or waht you're trying to do, rather than giving context on **why
-it is you think you have to do this**. For example,
+What may have happened here is that you asked a question that mostly consists
+of what you tried or what you're trying to do, rather than giving context on **why
+it is you think you have to do this in the first place**. For example,
 
 > You wanted to do `<X>`.
 > You ran into a problem with `<X>` or don't know how to do `<X>`.

--- a/advice-dont-ask-to-ask.md
+++ b/advice-dont-ask-to-ask.md
@@ -1,14 +1,12 @@
 # Don't ask to ask[^1]
 
-You may have been sent this document because **you asked to ask** a question,
-such as:
+You may have been sent this document because **you asked to ask** a question, such as:
 
-> You: Can someone message me about `<topic>`?<br/>
-> You: Can anyone help me with `<topic>`?<br/>
-> You: Does anyone know about `<topic>`?
+> You: Can someone message me about React Native?<br/>
+> You: Can anyone help me with Expo Updates?<br/>
+> You: Does anyone know about Swift UI with Expo?
 
-This isn't particularly productive and doesn't often lead to others being able to
-help you.
+These questions aren't particularly productive and don't often lead to others being able to help you.
 
 > [!TIP]
 > **tl;dr:** don't ask "Does anyone know about `<topic>`?", but rather ask:
@@ -16,10 +14,7 @@ help you.
 > - "Why is `<problem>` occurring when I do `<action>`?"
 > - "What do I do when I see `<issue>`, after I've done `<context>`?"
 
-There are plenty of reasons why people who otherwise would help you, may not be able
-to or may not commit to replying to you. If you ask to ask, you're omitting information
-about your problem or question, since you haven't formalized it. You are instead asking
-for something more broad and a large commitment from strangers.
+There are plenty of reasons why people who otherwise would help you, may not be able to or may not commit to replying to you. If you ask to ask, you're omitting information about your problem or question, since you haven't formalized it. You are instead asking for something more broad and a large commitment from strangers.
 
 Questions like the above cause conflict and problems because they:
 - ask others to take responsibility to take the lead
@@ -29,22 +24,20 @@ Questions like the above cause conflict and problems because they:
 - prompt people to commit to interviewing you to figure out your real question
 - obscure any replies, which prevents it from being useful to other people
 
-Others might see this as you not having done the work to diagnose your problem - and
-conclude that if _you_ didn't make any effort, why should _they_ now have to put in all the work to help solve the problem for you.
+Others might see this as you not having done the work to diagnose your problem - and conclude that if _you_ didn't make any effort, why should _they_ now have to put in all the work to help solve the problem for you.
 
 **Instead, take the time to form a question please.**
 
-The solution to the problem is not to ask to ask, but just to ask. Someone may see your question,
-and if they have an idea or recognize the problem, you are much more likely to get a reply.
+The solution to the problem is not to ask to ask, but just to ask. Someone may see your question, and if they have an idea or recognize the problem, you are much more likely to get a reply.
 
 **If you're not sure what to ask, describe your issue.**
+
+For example:
 
 > Can someone help me with `<topic>`?<br/>
 > I'm seeing `<problem>`, I've tried `<solution>`,<br/>
 > but instead of `<expected>`, I get `<symptom>`.
 
-Instead of leaving a message that only asks about a subject or topic, try describing your
-issue, even if you don't know what question to ask. If people recognize your problem or
-are interested in it, they are much more likely to help you, than if you had asked to ask.
+Instead of leaving a message that only asks about a subject or topic, try describing your issue, even if you don't know what question to ask. If people recognize your problem or are interested in it, they are much more likely to help you, than if you had asked to ask.
 
 [^1]: This document was inspired by https://dontasktoask.com/

--- a/advice-dont-ask-to-ask.md
+++ b/advice-dont-ask-to-ask.md
@@ -3,8 +3,8 @@
 You may have been sent this document because **you asked to ask** a question,
 such as:
 
-> You: Can someone message me about `<topic>`?
-> You: Can anyone help me with `<topic>`?
+> You: Can someone message me about `<topic>`?<br/>
+> You: Can anyone help me with `<topic>`?<br/>
 > You: Does anyone know about `<topic>`?
 
 This isn't particularly productive and doesn't often lead to others being able to
@@ -39,7 +39,8 @@ and if they have an idea or recognize the problem, chances are they'll reply.
 
 **If you're not sure what to ask, describe your issue.**
 
-> Can someone help me with `<topic>`? I'm seeing `<problem>`, I've tried `<solution>`,
+> Can someone help me with `<topic>`?<br/>
+> I'm seeing `<problem>`, I've tried `<solution>`,<br/>
 > but instead of `<expected>`, I get `<symptom>`.
 
 Instead of leaving a message that only asks about a subject or topic, try describing your

--- a/advice-dont-ask-to-ask.md
+++ b/advice-dont-ask-to-ask.md
@@ -26,16 +26,16 @@ Questions like the above cause conflict and problems because they:
 - question people's confidence and knowledge
 - wall out people who might be able to answer your question
 - ask for someone's undivided attention in real time
-- prompt people to commit to interviewing you to get to your real questions
+- prompt people to commit to interviewing you to figure out your real question
 - obscure any replies, which prevents it from being useful to other people
 
 Others might see this as you not having done the work to diagnose your problem - and
-conclude, why should they now put in any work to help you solve it.
+conclude that if _you_ didn't make any effort, why should _they_ now have to put in all the work to help solve the problem for you.
 
 **Instead, take the time to form a question please.**
 
 The solution to the problem is not to ask to ask, but just to ask. Someone may see your question,
-and if they have an idea or recognize the problem, chances are they'll reply.
+and if they have an idea or recognize the problem, you are much more likely to get a reply.
 
 **If you're not sure what to ask, describe your issue.**
 

--- a/advice-dont-ask-to-ask.md
+++ b/advice-dont-ask-to-ask.md
@@ -10,6 +10,12 @@ such as:
 This isn't particularly productive and doesn't often lead to others being able to
 help you.
 
+> [!TIP]
+> **tl;dr:** don't ask "Does anyone know about `<topic>`?", but rather ask:
+> - "How do I solve `<problem>` given `<context>`?"
+> - "Why is `<problem>` occurring when I do `<action>`?"
+> - "What do I do when I see `<issue>`, after I've done `<context>`?"
+
 There are plenty of reasons why people who otherwise would help you, may not be able
 to or may not commit to replying to you. If you ask to ask, you're omitting information
 about your problem or question, since you haven't formalized it. You are instead asking
@@ -39,12 +45,5 @@ and if they have an idea or recognize the problem, chances are they'll reply.
 Instead of leaving a message that only asks about a subject or topic, try describing your
 issue, even if you don't know what question to ask. If people recognize your problem or
 are interested in it, they are much more likely to help you, than if you had asked to ask.
-
-### tl;dr
-
-To summarize, don't ask "Does anyone know about `<topic>`?", but rather ask:
-- "How do I solve `<problem>` given `<context>`?"
-- "Why is `<problem>` occurring when I do `<action>`?"
-- "What do I do when I see `<issue>`, after I've done `<context>`?"
 
 [^1]: This document was inspired by https://dontasktoask.com/

--- a/advice-dont-ask-to-ask.md
+++ b/advice-dont-ask-to-ask.md
@@ -1,0 +1,50 @@
+# Don't ask to ask[^1]
+
+You may have been sent this document because **you asked to ask** a question,
+such as:
+
+> You: Can someone message me about <topic>?
+> You: Can anyone help me with <topic>?
+> You: Does anyone know about <topic>?
+
+This isn't particularly productive and doesn't often lead to others being able to
+help you.
+
+There are plenty of reasons why people who otherwise would help you, may not be able
+to or may not commit to replying to you. If you ask to ask, you're omitting information
+about your problem or question, since you haven't formalized it. You are instead asking
+for something more broad and a large commitment from strangers.
+
+Questions like the above cause conflict and problems because they:
+- ask others to take responsibility to take the lead
+- question people's confidence and knowledge
+- wall out people who might be able to answer your question
+- ask for someone's undivided attention in real time
+- prompt people to commit to interviewing you to get to your real questions
+- obscure any replies, which prevents it from being useful to other people
+
+Others might see this as you not having done the work to diagnose your problem - and
+conclude, why should they now put in any work to help you solve it.
+
+**Instead, take the time to form a question please.**
+
+The solution to the problem is not to ask to ask, but just to ask. Someone may see your question,
+and if they have an idea or recognize the problem, chances are they'll reply.
+
+**If you're not sure what to ask, describe your issue.**
+
+> Can someone help me with <topic>? I'm seeing <problem>, I've tried <solution>,
+> but instead of <expected>, I get <symptom>.
+
+Instead of leaving a message that only asks about a subject or topic, try describing your
+issue, even if you don't know what question to ask. If people recognize your problem or
+are interested in it, they are much more likely to help you, than if you had asked to ask.
+
+### tl;dr
+
+To summarize, don't ask "Does anyone know about <topic>?", but rather ask:
+- "How do I solve <problem> given <context>?"
+- "Why is <problem> occurring when I do <action>?"
+- "What do I do when I see <issue>, after I've done <context>?"
+
+[^1]: This document was inspired by https://dontasktoask.com/

--- a/advice-dont-ask-to-ask.md
+++ b/advice-dont-ask-to-ask.md
@@ -3,9 +3,9 @@
 You may have been sent this document because **you asked to ask** a question,
 such as:
 
-> You: Can someone message me about <topic>?
-> You: Can anyone help me with <topic>?
-> You: Does anyone know about <topic>?
+> You: Can someone message me about `<topic>`?
+> You: Can anyone help me with `<topic>`?
+> You: Does anyone know about `<topic>`?
 
 This isn't particularly productive and doesn't often lead to others being able to
 help you.
@@ -33,8 +33,8 @@ and if they have an idea or recognize the problem, chances are they'll reply.
 
 **If you're not sure what to ask, describe your issue.**
 
-> Can someone help me with <topic>? I'm seeing <problem>, I've tried <solution>,
-> but instead of <expected>, I get <symptom>.
+> Can someone help me with `<topic>`? I'm seeing `<problem>`, I've tried `<solution>`,
+> but instead of `<expected>`, I get `<symptom>`.
 
 Instead of leaving a message that only asks about a subject or topic, try describing your
 issue, even if you don't know what question to ask. If people recognize your problem or
@@ -42,9 +42,9 @@ are interested in it, they are much more likely to help you, than if you had ask
 
 ### tl;dr
 
-To summarize, don't ask "Does anyone know about <topic>?", but rather ask:
-- "How do I solve <problem> given <context>?"
-- "Why is <problem> occurring when I do <action>?"
-- "What do I do when I see <issue>, after I've done <context>?"
+To summarize, don't ask "Does anyone know about `<topic>`?", but rather ask:
+- "How do I solve `<problem>` given `<context>`?"
+- "Why is `<problem>` occurring when I do `<action>`?"
+- "What do I do when I see `<issue>`, after I've done `<context>`?"
 
 [^1]: This document was inspired by https://dontasktoask.com/

--- a/advice-dont-wait-to-ask.md
+++ b/advice-dont-wait-to-ask.md
@@ -9,26 +9,26 @@ such as:
 > You: `@someone`?
 
 In asynchronous messaging, this is similar to calling someone, then putting them on hold
-after they pick up. If you prompt someont to respond before asking your question, you won't
+after they pick up. If you prompt someone to respond before asking your question, you won't
 get an answer sooner but are instead asking for someone's attention.
 
 > [!TIP]
 > **tl;dr:** don't wait to ask your question or wait for someone to respond, but rather
 > write your question immediately.
 
-This causes conflict and problems because:
+Not writing your question in the first message causes conflict and problems because:
 - no one may respond, since they can't prioritize your message
 - someone may respond while you won't be there to ask your question
 - someone is prompted to give you their full attention to wait for your question
 
-Maybe you tried to be polite and wanted to ease someone into your question or introduce
-yourself before jumping into a request or asking for someone to commit to helping you - like
-one would in person or on the phone? That's great!
-But, online chats and forums are different.
+You may have done this with good intentions, tried to be polite, wanted to ease someone
+into your question, or introduce yourself before jumping into a request or asking for someone
+to commit to helping you - like one would in person or on the phone?
+Your intentions are admirable, but online chats and forums have different etiquette.
 
-Instead of letting someone respond in their own time, you're making them acknowledge your
-message before then making them wait for you to phrase your question, which is lost time for
-both you and the person responding (and that's frustrating for everyone).
+By asking to ask, instead of letting someone respond in their own time,
+you're making them acknowledge your message first, then wait for you to phrase your question,
+which is lost time for both you and the person responding (and that's frustrating for everyone).
 
 **Instead, just ask your question.**
 

--- a/advice-dont-wait-to-ask.md
+++ b/advice-dont-wait-to-ask.md
@@ -12,6 +12,10 @@ In asynchronous messaging, this is similar to calling someone, then putting them
 after they pick up. If you prompt someont to respond before asking your question, you won't
 get an answer sooner but are instead asking for someone's attention.
 
+> [!TIP]
+> **tl;dr:** don't wait to ask your question or wait for someone to respond, but rather
+> write your question immediately.
+
 This causes conflict and problems because:
 - no one may respond, since they can't prioritize your message
 - someone may respond while you won't be there to ask your question

--- a/advice-dont-wait-to-ask.md
+++ b/advice-dont-wait-to-ask.md
@@ -1,0 +1,44 @@
+# Don't wait to ask[^1]
+
+You may have been sent this document because **you waited to ask** a question,
+such as:
+
+> You: Hi
+> You: Anyone got a second?
+> You: Quick question.
+> You: @<someone>?
+
+In asynchronous messaging, this is similar to calling someone, then putting them on hold
+after they pick up. If you prompt someont to respond before asking your question, you won't
+get an answer sooner but are instead asking for someone's attention.
+
+This causes conflict and problems because:
+- no one may respond, since they can't prioritize your message
+- someone may respond while you won't be there to ask your question
+- someone is prompted to give you their full attention to wait for your question
+
+Maybe you tried to be polite and wanted to ease someone into your question or introduce
+yourself before jumping into a request or asking for someone to commit to helping you - like
+one would in person or on the phone? That's great!
+But, online chats and forums are different.
+
+Instead of letting someone respond in their own time, you're making them acknowledge your
+message before then making them wait for you to phrase your question, which is lost time for
+both you and the person responding (and that's frustrating for everyone).
+
+**Instead, just ask your question.**
+
+If you ask a question rather than asking for attention first, it's much more likely for someone
+to see your question or problem, and leave a quick reply. In chats, since messages can be read
+at any time and don't require someone's immediate attention, this makes sure chats stay asynchronous.
+
+**If you feel it's rude to simply ask a question, combine your question with an introduction.**
+
+> You: Hiya! <question>
+> You: Hi everyone, I'm <name>. <question>
+
+If you ask a question immediately, there's nothing stopping you from combining it with the introduction
+you originally wanted to write first - like a letter. This not only gives you time to formulate and
+write about your question or issue before others see it, it also allows you to introduce yourself.
+
+[^1]: This document was inspired by https://nohello.net/en/

--- a/advice-dont-wait-to-ask.md
+++ b/advice-dont-wait-to-ask.md
@@ -1,16 +1,13 @@
 # Don't wait to ask[^1]
 
-You may have been sent this document because **you waited to ask** a question,
-such as:
+You may have been sent this document because **you waited to ask** a question, such as:
 
 > You: Hi<br/>
 > You: Anyone got a second?<br/>
 > You: Quick question.<br/>
 > You: `@someone`?
 
-In asynchronous messaging, this is similar to calling someone, then putting them on hold
-after they pick up. If you prompt someone to respond before asking your question, you won't
-get an answer sooner but are instead asking for someone's attention.
+In asynchronous messaging, this is similar to calling someone, then putting them on hold after they pick up. If you prompt someone to respond before asking your question, you won't get an answer sooner but are instead asking for someone's attention.
 
 > [!TIP]
 > **tl;dr:** don't wait to ask your question or wait for someone to respond, but rather
@@ -21,28 +18,18 @@ Not writing your question in the first message causes conflict and problems beca
 - someone may respond while you won't be there to ask your question
 - someone is prompted to give you their full attention to wait for your question
 
-You may have done this with good intentions, tried to be polite, wanted to ease someone
-into your question, or introduce yourself before jumping into a request or asking for someone
-to commit to helping you - like one would in person or on the phone?
-Your intentions are admirable, but online chats and forums have different etiquette.
+You may have done this with good intentions, tried to be polite, wanted to ease someone into your question, or introduce yourself before jumping into a request or asking for someone to commit to helping you - like one would in person or on the phone? Your intentions are admirable, but online chats and forums have different etiquette.
 
-By asking to ask, instead of letting someone respond in their own time,
-you're making them acknowledge your message first, then wait for you to phrase your question,
-which is lost time for both you and the person responding (and that's frustrating for everyone).
+By asking to ask, instead of letting someone respond in their own time, you're making them acknowledge your message first, then wait for you to phrase your question, which is lost time for both you and the person responding (and that's frustrating for everyone).
 
 **Instead, just ask your question.**
 
-If you ask a question rather than asking for attention first, it's much more likely for someone
-to see your question or problem, and leave a quick reply. In chats, since messages can be read
-at any time and don't require someone's immediate attention, this makes sure chats stay asynchronous.
+If you ask a question rather than asking for attention first, it's much more likely for someone to see your question or problem, and leave a quick reply. In chats, since messages can be read at any time and don't require someone's immediate attention, this makes sure chats stay asynchronous.
 
 **If you feel it's rude to simply ask a question, combine your question with an introduction.**
 
-> You: Hiya! `<question>`<br/>
-> You: Hi everyone, I'm `<name>`. `<question>`
+> You: Hi everyone, I'm `<name>`! What command do I run to upgrade to the new Expo SDK?
 
-If you ask a question immediately, there's nothing stopping you from combining it with the introduction
-you originally wanted to write first - like a letter. This not only gives you time to formulate and
-write about your question or issue before others see it, it also allows you to introduce yourself.
+If you ask a question immediately, there's nothing stopping you from combining it with the introduction you originally wanted to write first - like a letter. This not only gives you time to formulate and write about your question or issue before others see it, it also allows you to introduce yourself.
 
 [^1]: This document was inspired by https://nohello.net/en/

--- a/advice-dont-wait-to-ask.md
+++ b/advice-dont-wait-to-ask.md
@@ -6,7 +6,7 @@ such as:
 > You: Hi
 > You: Anyone got a second?
 > You: Quick question.
-> You: @<someone>?
+> You: `@someone`?
 
 In asynchronous messaging, this is similar to calling someone, then putting them on hold
 after they pick up. If you prompt someont to respond before asking your question, you won't
@@ -34,8 +34,8 @@ at any time and don't require someone's immediate attention, this makes sure cha
 
 **If you feel it's rude to simply ask a question, combine your question with an introduction.**
 
-> You: Hiya! <question>
-> You: Hi everyone, I'm <name>. <question>
+> You: Hiya! `<question>`
+> You: Hi everyone, I'm `<name>`. `<question>`
 
 If you ask a question immediately, there's nothing stopping you from combining it with the introduction
 you originally wanted to write first - like a letter. This not only gives you time to formulate and

--- a/advice-dont-wait-to-ask.md
+++ b/advice-dont-wait-to-ask.md
@@ -3,9 +3,9 @@
 You may have been sent this document because **you waited to ask** a question,
 such as:
 
-> You: Hi
-> You: Anyone got a second?
-> You: Quick question.
+> You: Hi<br/>
+> You: Anyone got a second?<br/>
+> You: Quick question.<br/>
 > You: `@someone`?
 
 In asynchronous messaging, this is similar to calling someone, then putting them on hold
@@ -38,7 +38,7 @@ at any time and don't require someone's immediate attention, this makes sure cha
 
 **If you feel it's rude to simply ask a question, combine your question with an introduction.**
 
-> You: Hiya! `<question>`
+> You: Hiya! `<question>`<br/>
 > You: Hi everyone, I'm `<name>`. `<question>`
 
 If you ask a question immediately, there's nothing stopping you from combining it with the introduction


### PR DESCRIPTION
Currently, we're receiving a lot of messages on Discord that ultimately go unanswered. This often is caused by four main reasons:
- The poster asked to ask
- The poster asked about a solution without stating their problem
- The poster waited to ask
- The poster didn't give an issue report for an issue

This PR proposes to add three advice documents to this repo that can be used to reply to messages fitting the first three reasons above.

The fourth reason is excluded since it requires us to write a longer and more comprehensive document that would have to encompass a lot of advice on how to write a proper issue report (like an issue template++)

Most of these documents are based on existing docs that are out in the internet,
but have been rephrased to:
- repeat the advice they contain and rephrase it at least once, since non-native speakers may read it
- not antagonise the reader but be constructive instead
- give them more actionable feedback
- explain in more detail why they've been sent these documents

### Don't ask to ask

This is a document for people that asked whether it's ok to ask, e.g.
- "May I ask a question about EAS Builds?"
- "Has someone worked with Expo Image?"
- "Can someone DM me / talk to me about React Native project structures?"
- "Would someone be willing to help me with my issue?"

Questions like these aren't actually asking a proper question, but are people asking to ask.
The document `advice-dont-ask-to-ask.md` tells them to try to instead form a full question or state their problem

## Don't ask about solutions

This is a document for people that either have asked about a solution that isn't working, that we suspect are about to cause "the XY Problem", or are simply not stating their problem, e.g.
- "I did [Y] and it did not work."
- "How would I implement [Y]?"
- "Would [Y] work and do [X]?"

Questions like these are either omitting all context on the original problem, are obscuring the problem, or are coming to a conversation with a solution without stating the full problem.
This often causes frustration on both sides, since the solution may either not be needed, not be the easiest, not be necessary, or is unrelated to the underlying problem.

## Don't wait to ask

This is a document for messages that simply announce or precede a _future_ question, e.g.
- "Hi"
- "Quick question"
- "Anyone there?"

This is slightly distinct from "Don't ask to ask", since it may even happen several messages into a conversation. This happens when a poster is either looking for someone's undivided attention (which is unnecessary) or when they'd like to ease someone into a question.

Either way, this leads to unnecessary waiting time, and instead of combining an introduction with their question, they instead are prompting someone to respond first while then also making them wait for the actual question.