### PR TITLE
Add instructions to disable auto-installing peers for Bun

### DIFF
--- a/resolving-dependency-issues.md
+++ b/resolving-dependency-issues.md
@@ -257,7 +257,7 @@ autoInstallPeers: false
 <details>
 <summary><strong>Disabling auto-installing peer dependencies for Bun</strong></summary>
 
-To disable automatically installed peer dependencies for pnpm, add `peer = false` to the `[install]` section of your `bunfig.toml` file in your project:
+To disable automatically installed peer dependencies for Bun, add `peer = false` to the `[install]` section of your `bunfig.toml` file in your project:
 
 ```toml
 [install]

--- a/resolving-dependency-issues.md
+++ b/resolving-dependency-issues.md
@@ -254,6 +254,18 @@ autoInstallPeers: false
 
 </details>
 
+<details>
+<summary><strong>Disabling auto-installing peer dependencies for Bun</strong></summary>
+
+To disable automatically installed peer dependencies for pnpm, add `peer = false` to the `[install]` section of your `bunfig.toml` file in your project:
+
+```toml
+[install]
+peer = false
+```
+
+</details>
+
 ### 3. Run Expo Doctor after upgrading
 
 When upgrading your Expo SDK version (no matter if it's an update or a new major release), or after upgrading native modules, or after upgrading dependencies, please run Expo Doctor to quickly check whether your project's dependencies are still in a clean state.


### PR DESCRIPTION
We can add instructions for Bun here as well. It seems like not having this in Bun <1.2.20 with isolated dependencies and in some lockfile conditions (moving from hoisted to isolated) can cause duplication otherwise, that's then captured by the lockfile.

Adding instructions for Bun to disable this is quite straightforward