### PR TITLE
docs(expo-54-reanimated): fix typos

### DIFF
--- a/expo-54-reanimated.md
+++ b/expo-54-reanimated.md
@@ -1,17 +1,18 @@
-# Renimated and SKD 54
+# Reanimated and SDK 54
 
-With the release of SDK 54, the recommended version of `react-native-reanimated` has moved to `4.x`. For many apps, upgrading will involve some manual steps, like installing the `react-native-worklets` package. 
+With the release of SDK 54, the recommended version of `react-native-reanimated` has moved to `4.x`. For many apps, upgrading will involve some manual steps, like installing the `react-native-worklets` package.
 You'll find all the necessary steps in the official migration guide provided by the Reanimated team [here](https://docs.swmansion.com/react-native-reanimated/docs/guides/migration-from-3.x/).
 
-A key point to note: if you're using `expo-babel-preset`, it automatically manages the reanimated Babel plugin for you. 
+A key point to note: if you're using `babel-preset-expo`, it automatically manages the reanimated Babel plugin for you.
 This means there's no need to change it to `react-native-worklets/plugin`, unless you manually specified a plugin in your project configuration.
 
-# Using SDK 54 with legacy architecture 
+# Using SDK 54 with legacy architecture
 
 Although SDK 54 supports the legacy architecture, keep in mind that `react-native-reanimated` v4 is designed exclusively for the new architecture. We highly recommend making the switch to the new architecture when you can.
 If that's not feasible, you can still use SDK 54 with the legacy architecture, but you will need to downgrade `react-native-reanimated` to version v3.
 
 Since our tooling enforces the default version of packages, you will need to exclude `react-native-reanimated` from being checked by adding those lines to `package.json`:
+
 ```
 {
   "expo": {


### PR DESCRIPTION
Noticed some typos while reading this, this fixes those!

This document could also likely describe how to properly configure babel to utilize reanimated 3 with SDK 54 (in new arch). I haven't found the working combination yet, but it seems needed for projects with bottom sheet installed