### PR TITLE
Add eas go fyi docs

### DIFF
--- a/deploy-expo-go-testflight.md
+++ b/deploy-expo-go-testflight.md
@@ -1,13 +1,13 @@
 # Deploy Expo Go to your TestFlight internal team
 
-The `eas go` command builds a version of the Expo Go app on EAS and deploys it to your TestFlight internal team — making it available to install on any device in your team. It currently only supports SDK 55, but in the future this will make it possible for you to choose the SDK version of Expo Go that you install on your device. So if you're in the middle of exploring an idea or learning something with Expo Go, you can continue uninterrupted, regardless of SDK releases.
+The `eas go` command builds a version of the Expo Go app on EAS and deploys it to your TestFlight internal team — making it available to install on any device in your team. You can choose the SDK version with `--sdk-version`, so if you're in the middle of exploring an idea or learning something with Expo Go, you can stay on the SDK you need regardless of releases.
 
 That said, you may alternatively want to consider migrating your project to using a [development build](https://docs.expo.dev/develop/development-builds/expo-go-to-dev-build/), which provides you with everything that you need to build an app that you ship to stores.
 
 ## How it works
 
-1. Run `eas go` from your project directory.
-2. EAS builds the Expo Go app for your project's SDK version.
+1. Run `eas go` from anywhere — no local project setup needed.
+2. EAS builds the Expo Go app for the SDK version you choose (defaults to the latest supported).
 3. The build is automatically submitted to App Store Connect.
 4. Your TestFlight internal team members receive it as a TestFlight build they can install on their devices.
 

--- a/personal-expo-go.md
+++ b/personal-expo-go.md
@@ -1,0 +1,41 @@
+# Your personal Expo Go on TestFlight
+
+After `eas go` completes, your custom Expo Go build has been submitted to App Store Connect and is on its way to TestFlight.
+
+## What to expect
+
+**App Store processing takes a few minutes.** Once it's done, the build will appear in TestFlight and anyone on your internal test team will be able to install it.
+
+You can check the status at any time on [App Store Connect](https://appstoreconnect.apple.com).
+
+## Installing on a device
+
+1. Open the **TestFlight** app on your iOS device.
+2. Find your Expo Go build and tap **Install**.
+3. Once installed, open it and scan a QR code or enter a project URL as you normally would.
+
+## Using a specific SDK version
+
+By default, `eas go` uses the latest supported SDK. To pin a version:
+
+```bash
+eas go --sdk-version 55
+```
+
+## Sharing with your team
+
+The build is distributed as a TestFlight internal build, so anyone you've added to your App Store Connect internal test group can install it directly from TestFlight — no App Store review required.
+
+## FAQ
+
+**The build doesn't appear in TestFlight yet.**
+
+App Store Connect processing usually takes 5–15 minutes. If it's been longer, check App Store Connect for any compliance or export issues.
+
+**Can I have multiple SDK versions installed at once?**
+
+No — like the public Expo Go, only one version can be installed at a time. Run `eas go --sdk-version <version>` to switch.
+
+**Is this the same app as the public Expo Go?**
+
+It uses the same Expo Go source but is signed with your Apple Developer account and distributed through your own TestFlight, so it's treated as a separate app on the device.

--- a/personal-expo-go.md
+++ b/personal-expo-go.md
@@ -19,7 +19,7 @@ You can check the status at any time on [App Store Connect](https://appstoreconn
 By default, `eas go` uses the latest supported SDK. To pin a version:
 
 ```bash
-eas go --sdk-version 55
+eas go --sdk-version 55.0.0
 ```
 
 ## Sharing with your team


### PR DESCRIPTION
## Why

`eas go` is a new EAS CLI command that builds a custom Expo Go IPA on EAS and deploys it to your TestFlight internal team. Two doc changes to support it:

- **`deploy-expo-go-testflight.md`** — already existed but described a manual flow. expo.dev/go now links here ("Learn more") so it needs to reflect the new `eas go` CLI instead.
- **`personal-expo-go.md`** — new doc linked by the CLI after `eas go` completes, explaining what to expect (TestFlight processing, how to install, sharing with team). The link has been in the CLI for a while, but the doc was never created — so this is fixing a pre-existing 404, not a regression from today's release.

## How

- Updated `deploy-expo-go-testflight.md` with Getting started, How it works, and FAQ sections covering `eas go`
- Added `personal-expo-go.md` as a post-command landing page covering TestFlight processing time, device install steps, SDK pinning, and team sharing